### PR TITLE
minor updates & fixes

### DIFF
--- a/scripts/mesos_install_ubuntu.sh
+++ b/scripts/mesos_install_ubuntu.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -e
 
 # Setup
-sudo dpkg -s mesos
-if [ $? -eq 0 ]
-	then
-	echo "Mesos is already installed"
-	exit $?
-fi
+# TBD always exits script with error because of 'bash -e'
+# sudo dpkg-query -l mesos
+# if [ $? -eq 0 ]
+# 	then
+# 	echo "Mesos is already installed"
+# 	exit $?
+# fi
 
 if [ -z "$MESOS_VERSION" ]
 	then

--- a/scripts/openvpn_install_redhat.sh
+++ b/scripts/openvpn_install_redhat.sh
@@ -6,8 +6,8 @@ if [ ${HOSTNAME: -1} -eq 0 ]
 then
   # install packages
   sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  sudo yum install -y openvpn easy-rsa 
-  
+  sudo yum install -y openvpn easy-rsa
+
   # use default openvpn configuration
   cd /etc/openvpn
   sudo cp  /usr/share/doc/openvpn*/sample/sample-config-files/server.conf server.conf > /dev/null
@@ -62,24 +62,24 @@ then
 
   # enable whole network on vpn
   sudo firewall-cmd --add-masquerade
-  sudo firewall-cmd --permanenet --add-masquerade
-  
+  sudo firewall-cmd --permanent --add-masquerade
+
   # create client certificates
   sudo -E ./pkitool client1
 
-  # template client config file 
+  # template client config file
   mkdir ~/openvpn && cd ~/openvpn
   sudo cp /usr/share/doc/openvpn*/sample/sample-config-files/client.conf client.ovpn
 
   # update client configuration
-  IP=$(curl http://ipecho.net/plain)
+  IP=$(curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
   sudo sed -i "s/remote my-server-1 1194/remote ${IP} 1194/g" client.ovpn
   sudo sed -i "s/;user nobody/user nobody/g" client.ovpn
   sudo sed -i "s/;group nogroup/group nogroup/g" client.ovpn
   sudo sed -i "s/ca ca.crt/;ca ca.crt/g" client.ovpn
   sudo sed -i "s/cert client.crt/;cert client.crt/g" client.ovpn
   sudo sed -i "s/key client.key/;key client.key/g" client.ovpn
-  echo -e "\n<ca>\n$(sudo cat keys/ca.crt)\n</ca>\n" | sudo tee -a client.ovpn > /dev/null
-  echo -e "\n<cert>\n$(sudo cat keys/client1.crt)\n</cert>\n" | sudo tee -a client.ovpn > /dev/null
-  echo -e "\n<key>\n$(sudo cat keys/client1.key)\n</key>\n" | sudo tee -a client.ovpn > /dev/null
+  echo -e "\n<ca>\n$(sudo cat /etc/openvpn/easy-rsa/2.0/keys/ca.crt)\n</ca>\n" | sudo tee -a client.ovpn > /dev/null
+  echo -e "\n<cert>\n$(sudo cat /etc/openvpn/easy-rsa/2.0/keys/client1.crt)\n</cert>\n" | sudo tee -a client.ovpn > /dev/null
+  echo -e "\n<key>\n$(sudo cat /etc/openvpn/easy-rsa/2.0/keys/client1.key)\n</key>\n" | sudo tee -a client.ovpn > /dev/null
 fi

--- a/scripts/openvpn_install_ubuntu.sh
+++ b/scripts/openvpn_install_ubuntu.sh
@@ -6,7 +6,7 @@ if [ ${HOSTNAME: -1} -eq 0 ]
 then
   # install packages
   sudo apt-get -y install openvpn easy-rsa
-  
+
   # use default openvpn configuration
   cd /etc/openvpn
   gunzip -c /usr/share/doc/openvpn/examples/sample-config-files/server.conf.gz | sudo tee server.conf > /dev/null
@@ -59,16 +59,16 @@ then
 
   # enable whole network on vpn
   sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-  
+
   # create client certificates
   sudo -E ./pkitool client1
 
-  # template client config file 
+  # template client config file
   mkdir ~/openvpn && cd ~/openvpn
   sudo cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf client.ovpn
 
   # update client configuration
-  IP=$(curl http://ipecho.net/plain)
+  IP=$(curl -fsSL -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
   sudo sed -i "s/remote my-server-1 1194/remote ${IP} 1194/g" client.ovpn
   sudo sed -i "s/;user nobody/user nobody/g" client.ovpn
   sudo sed -i "s/;group nogroup/group nogroup/g" client.ovpn


### PR DESCRIPTION
scripts/mesos_install_ubuntu.sh always exits with an error due to `sudo dpkg -s mesos` This caused to stop terraform. Tried several workarounds, wasn't able to make them work other than `set -e` after the test. For now disabled for mesos.

scripts/openvpn_install_redhat.sh:
- fixed a typo `--permanent`
- `IP=$(curl http://ipecho.net/plain)` sometimes failed
- client.ovpn didn't included ca.crt, client1.crt & client1.key

The interface of https://console.developers.google.com was changed. In README.md rewrote steps for generating json account_file. Other minor clarifications. 
