### PR TITLE
bash -e caused mesos_install_ubuntu.sh always to exit

### DIFF
--- a/scripts/mesos_install_ubuntu.sh
+++ b/scripts/mesos_install_ubuntu.sh
@@ -1,12 +1,14 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Setup
-sudo dpkg -s mesos
+set +e
+sudo dpkg-query -l mesos
 if [ $? -eq 0 ]
 	then
 	echo "Mesos is already installed"
 	exit $?
 fi
+set -e
 
 if [ -z "$MESOS_VERSION" ]
 	then


### PR DESCRIPTION
`set +e` temporally disables exiting
